### PR TITLE
remove spans in org heading - makes all text in heading uniform color

### DIFF
--- a/app/assets/javascripts/application/templates/titles/titleOrganization.handlebars
+++ b/app/assets/javascripts/application/templates/titles/titleOrganization.handlebars
@@ -1,1 +1,1 @@
-<span>{{projects}}</span> by <span>{{name}}</span> {{#if country}}in {{country}}{{/if}}
+{{projects}} by {{name}} {{#if country}}in {{country}}{{/if}}


### PR DESCRIPTION
#51 