### PR TITLE
add event to hide menus on mouseleave

### DIFF
--- a/app/views/partials/_categories_selector.html.erb
+++ b/app/views/partials/_categories_selector.html.erb
@@ -132,6 +132,15 @@
           menu.classList.add('-show');
         }
       });
+
+      button.addEventListener('mouseleave', function(e) {
+        var target   = e.currentTarget;
+        var menus    = target.parentElement.parentElement.querySelectorAll('.menu');
+
+        for (var i=0, len=menus.length; i < len; i++) {
+          menus[i].classList.remove('-show');
+        }
+      });
     }
   </script>
 <% end %>


### PR DESCRIPTION
#53 

Improve the experience with the hover menus on the nav below the map.  So things don't overlap, hide menus on `mouseleave` so only one is ever showing.  This doesn't effect the keyboard interactions.