### PR TITLE
remove duplicate, misspelled fields from sectors

### DIFF
--- a/db/migrate/20170104155053_remove_duplicate_fields_from_sectors.rb
+++ b/db/migrate/20170104155053_remove_duplicate_fields_from_sectors.rb
@@ -1,0 +1,6 @@
+class RemoveDuplicateFieldsFromSectors < ActiveRecord::Migration
+  def change
+      remove_column :sectors, :oec_dac_name
+      remove_column :sectors, :oec_dac_purpose_code
+  end
+end


### PR DESCRIPTION
Based on existing migrations, these mis-spelled fields should have been replaced, but somehow the correct versions (using "oecd", not "oec") were duplicated.  