### PR TITLE
fix - remove menu button focus state when using mouse and mouse leave

### DIFF
--- a/app/views/partials/_categories_selector.html.erb
+++ b/app/views/partials/_categories_selector.html.erb
@@ -137,10 +137,12 @@
       parent.addEventListener('mouseleave', function(e) {
         var target = e.currentTarget;
         var menus  = target.parentElement.querySelectorAll('.menu');
+        var button = target.querySelector('button.father');
 
         for (var i=0, len=menus.length; i < len; i++) {
           menus[i].classList.remove('-show');
         }
+        button.blur();
       });
     }
   </script>


### PR DESCRIPTION
#53 

Remove the button focus state when using a mouse on the Sectors/Orgs/Donors menu.